### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/nuget-publish-core.yml
+++ b/.github/workflows/nuget-publish-core.yml
@@ -1,4 +1,4 @@
-name: NuGet Publish Core
+name: NuGet Build
 
 on:
   pull_request:

--- a/.github/workflows/nuget-publish-dependencyinjection.yml
+++ b/.github/workflows/nuget-publish-dependencyinjection.yml
@@ -1,4 +1,4 @@
-name: NuGet Publish DependencyInjection
+name: NuGet Build
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Ripe.Sdk
+[![Unit Tests](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml)
 
-//TODO: build status
-//TODO: package references
+Package|Version|Status
+-|-|-
+[Ripe.Sdk.Core](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.Core)|1.1.0|[![NuGet Build](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-core.yml/badge.svg?branch=main)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-core.yml)
+[Ripe.Sdk.DependencyInjection](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.DependencyInjection)|1.1.0|[![NuGet Build](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-dependencyinjection.yml/badge.svg?branch=main)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-dependencyinjection.yml)
 
-* [Ripe.Sdk.Core](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.Core)
-* [Ripe.Sdk.DependencyInjection](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.DependencyInjection)

--- a/Ripe.Sdk.Core/README.md
+++ b/Ripe.Sdk.Core/README.md
@@ -1,9 +1,17 @@
 # Ripe.Sdk.Core
 
+[![NuGet Build](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish.yml/badge.svg?branch=main)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish.yml)
+[![Unit Tests](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml)
+
 The Ripe Core package includes the bare minimum to get started with Ripe, used mostly for Console and Desktop applications. If you're looking for 
 a package that supports modern dependency injection via the `IConfigurationBuilder`, then navigate [here](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.DependencyInjection)
 
 ## Getting Started
+Install Ripe.Sdk
+```
+dotnet add package Ripe.Sdk.Core
+```
+
 Create a class that will hold your configuration, inheriting from `IRipeConfiguration`:
 ```csharp
 public class Config : IRipeConfiguration

--- a/Ripe.Sdk.Core/Ripe.Sdk.Core.csproj
+++ b/Ripe.Sdk.Core/Ripe.Sdk.Core.csproj
@@ -1,35 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-	  <Version>1.0.0.0</Version>
-	  <Title>Ripe Sdk Core</Title>
-	  <Authors>Matthew Andrews</Authors>
-	  <PackageIcon>logox128.png</PackageIcon>
-	  <PackageReleaseNotes>Initial release</PackageReleaseNotes>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <PackageProjectUrl>https://github.com/matt-andrews/Ripe.Sdk</PackageProjectUrl>
-	  <RepositoryUrl>https://github.com/matt-andrews/Ripe.Sdk</RepositoryUrl>
-	  <Description>A dotnet standard library for interfacing with Ripe Config </Description>
-	  <PackageTags>ripe, ripe config</PackageTags>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<Version>1.1.0</Version>
+		<Title>Ripe Sdk Core</Title>
+		<Authors>Matthew Andrews</Authors>
+		<PackageIcon>logox128.png</PackageIcon>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageProjectUrl>https://github.com/matt-andrews/Ripe.Sdk</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/matt-andrews/Ripe.Sdk</RepositoryUrl>
+		<Description>A dotnet standard library for interfacing with Ripe Config </Description>
+		<PackageTags>ripe, ripe config</PackageTags>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\logox128.png">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\logox128.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Text.Json" Version="8.*" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Ripe.Sdk.Core/RipePropertyNameAttribute.cs
+++ b/Ripe.Sdk.Core/RipePropertyNameAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Ripe.Sdk.Core
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class RipePropertyNameAttribute : Attribute
+    {
+        public string PropertyName { get; set; }
+        public RipePropertyNameAttribute(string propertyName)
+        {
+            PropertyName = propertyName;
+        }
+    }
+    internal sealed class RipePropertyNameContract
+    {
+        public static void Contract(JsonTypeInfo typeInfo)
+        {
+            foreach(JsonPropertyInfo prop in typeInfo.Properties)
+            {
+                var attr = prop.AttributeProvider.GetCustomAttributes(true).FirstOrDefault(f => f is RipePropertyNameAttribute);
+                if(attr is RipePropertyNameAttribute attribute)
+                {
+                    prop.Name = attribute.PropertyName;
+                }
+            }
+        }
+    }
+}

--- a/Ripe.Sdk.DependencyInjection/README.md
+++ b/Ripe.Sdk.DependencyInjection/README.md
@@ -1,10 +1,18 @@
 # Ripe.Sdk.DependencyInjection
 
+[![NuGet Build](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-dependencyinjection.yml/badge.svg?branch=main)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/nuget-publish-dependencyinjection.yml)
+[![Unit Tests](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/matt-andrews/Ripe.Sdk/actions/workflows/unit-tests.yml)
+
 The Ripe Dependency Injection package includes extensions for integrating with the `IConfigurationBuilder` during setup to pull your configuration 
 into `IConfiguration`, as well as inject your config as a scoped service which is automatically refreshed in regular intervals.
 
 ## Getting Started
 Follow the guide [here](https://github.com/matt-andrews/Ripe.Sdk/tree/main/Ripe.Sdk.Core) to learn how to create an `IRipeConfiguration` object to base your configuration on. 
+
+Install Ripe.Sdk.DependencyInjection
+```
+dotnet add package Ripe.Sdk.DependencyInjection
+```
 
 Once you have your configuration object created, you can inject your configuration like so:
 ```csharp

--- a/Ripe.Sdk.DependencyInjection/Ripe.Sdk.DependencyInjection.csproj
+++ b/Ripe.Sdk.DependencyInjection/Ripe.Sdk.DependencyInjection.csproj
@@ -1,40 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Title>Ripe Sdk Dependency Injection</Title>
-    <Authors>Matthew Andrews</Authors>
-    <PackageIcon>logox128.png</PackageIcon>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial Release</PackageReleaseNotes>
-    <PackageProjectUrl>https://github.com/matt-andrews/Ripe.Sdk</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/matt-andrews/Ripe.Sdk</RepositoryUrl>
-    <Description>A dotnet standard library for enabling dependency injection with Ripe.Sdk.Core</Description>
-    <PackageTags>ripe, ripe config, dependency injection</PackageTags>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+		<Version>1.1.0</Version>
+		<Title>Ripe Sdk Dependency Injection</Title>
+		<Authors>Matthew Andrews</Authors>
+		<PackageIcon>logox128.png</PackageIcon>
+		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageProjectUrl>https://github.com/matt-andrews/Ripe.Sdk</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/matt-andrews/Ripe.Sdk</RepositoryUrl>
+		<Description>A dotnet standard library for enabling dependency injection with Ripe.Sdk.Core</Description>
+		<PackageTags>ripe, ripe config, dependency injection</PackageTags>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\logox128.png">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\logox128.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.*" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.*" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Ripe.Sdk.Core\Ripe.Sdk.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Ripe.Sdk.Core\Ripe.Sdk.Core.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Ripe.Sdk.DependencyInjection/RipeConfigurationSource.cs
+++ b/Ripe.Sdk.DependencyInjection/RipeConfigurationSource.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Ripe.Sdk.Core;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Ripe.Sdk.DependencyInjection
@@ -48,7 +49,8 @@ namespace Ripe.Sdk.DependencyInjection
                 if (prop.PropertyType == typeof(string)
                     || prop.PropertyType == typeof(int)
                     || prop.PropertyType == typeof(decimal)
-                    || prop.PropertyType == typeof(bool))
+                    || prop.PropertyType == typeof(bool)
+                    || typeof(IDictionary).IsAssignableFrom(prop.PropertyType))
                 {
                     result.Add(GetPrefix(prefix, prop.Name), prop.GetValue(obj).ToString());
                 }

--- a/Ripe.Sdk.Tests/UnitTest1.cs
+++ b/Ripe.Sdk.Tests/UnitTest1.cs
@@ -190,7 +190,7 @@ namespace Ripe.Sdk.Tests
                 })
                 .Build();
             var provider = services.BuildServiceProvider();
-            var configService = provider.GetRequiredService<RipeSdk<MockRipeConfig>>();
+            var configService = provider.GetRequiredService<IRipeSdk<MockRipeConfig>>();
             configService.Hydrate();
             configService.Hydrate();
             configService.Hydrate();
@@ -211,7 +211,7 @@ namespace Ripe.Sdk.Tests
                 })
                 .Build();
             var provider = services.BuildServiceProvider();
-            var configService = provider.GetRequiredService<RipeSdk<MockRipeConfig>>();
+            var configService = provider.GetRequiredService<IRipeSdk<MockRipeConfig>>();
             await configService.HydrateAsync();
             await configService.HydrateAsync();
             await configService.HydrateAsync();
@@ -233,7 +233,7 @@ namespace Ripe.Sdk.Tests
                 .Build();
 
             var provider = services.BuildServiceProvider();
-            var configService = provider.GetRequiredService<RipeSdk<MockRipeConfig>>();
+            var configService = provider.GetRequiredService<IRipeSdk<MockRipeConfig>>();
             var configObj = await configService.HydrateAsync();
             Assert.That(configObj.TimeToLive, Is.EqualTo(0));
             


### PR DESCRIPTION
## Changes
* Updated readme and package information
* Fixed an issue with `Dictionary<,>` property in configuration failing to serialize/deserialize
* Fixed an issue where DI was failing to inject users `IRipeConfiguration`
* Added `RipePropertyName` Attribute to allow users to use a different property name than the key name in Ripe